### PR TITLE
Throttling

### DIFF
--- a/Opts.hs
+++ b/Opts.hs
@@ -5,6 +5,7 @@ import           Options.Applicative
 data WatchOpt = WatchOpt { watchPath   :: String
                          , includePath :: String  -- ^ an reg exp to include particular files when watching dir
                          , excludePath :: String  -- ^ an reg exp to exclude particular files when watching dir
+                         , throttlingDelay :: Int     -- ^ milliseconds to wait for duplicate events
                          , actionCmd   :: [String]
                          } deriving (Show)
 
@@ -21,5 +22,9 @@ watchOpt = WatchOpt
                     <> value []
                     <> metavar "EXCLUDE"
                     <> help "pattern for excluding files")
+     <*> option auto (long "throttle"
+                    <> value 0
+                    <> metavar "MILLIS"
+                    <> help "milliseconds to wait for duplicate events")
      <*> (many . strArgument) (metavar "COMMAND"
                       <> help "command to run" )

--- a/Pipeline.hs
+++ b/Pipeline.hs
@@ -1,0 +1,33 @@
+-- poor man's streaming library, using threads communicating with MVars
+module Pipeline where
+
+import Prelude hiding (id, (.))
+
+import Control.Category
+import Control.Concurrent
+import Control.Concurrent.MVar
+import Control.Monad
+
+
+newtype Pipeline a b = Pipeline {
+  -- launches zero or more threads, forming a pipeline which takes from
+  -- the 'MVar a' and puts to the 'MVar b'.
+  runPipeline :: MVar a -> IO ([ThreadId], MVar b)
+}
+
+instance Category Pipeline where
+    id = Pipeline $ \inputMVar -> return ([], inputMVar)
+    s2 . s1 = Pipeline $ \inputMVar -> do
+      (threads1, intermediateMVar) <- runPipeline s1 inputMVar
+      (threads2, outputMVar) <- runPipeline s2 intermediateMVar
+      return (threads1 ++ threads2, outputMVar)
+
+
+mkPipeline :: (a -> IO b) -> Pipeline a b
+mkPipeline f = Pipeline $ \inputMVar -> do
+    outputMVar <- newEmptyMVar
+    threadId <- forkIO $ forever $ do
+      x <- takeMVar inputMVar
+      y <- f x
+      putMVar outputMVar y
+    return ([threadId], outputMVar)

--- a/fswatcher.cabal
+++ b/fswatcher.cabal
@@ -27,6 +27,7 @@ Executable fswatcher
                    , regex-pcre-builtin   >= 0.94
     ghc-options:     -Wall
     main-is:         fswatcher.hs
+    other-modules:   Opts
 
 source-repository head
   type:     git

--- a/fswatcher.cabal
+++ b/fswatcher.cabal
@@ -28,6 +28,7 @@ Executable fswatcher
     ghc-options:     -Wall
     main-is:         fswatcher.hs
     other-modules:   Opts
+                   , Pipeline
 
 source-repository head
   type:     git

--- a/fswatcher.hs
+++ b/fswatcher.hs
@@ -1,5 +1,7 @@
 {-# LANGUAGE OverloadedStrings #-}
 
+import Prelude hiding (id, (.))
+
 import System.IO (hPutStrLn, stderr)
 import System.Posix.Files (getFileStatus, isDirectory)
 import System.Directory (canonicalizePath, getCurrentDirectory)
@@ -10,6 +12,7 @@ import System.FSNotify (Event (..), StopListening, WatchManager, startManager,
        stopManager, watchTree, watchDir, eventPath)
 import System.Exit (ExitCode (..), exitSuccess)
 import System.Process (createProcess, proc, waitForProcess)
+import Control.Category
 import Control.Monad (void)
 import System.Posix.Signals (installHandler, Handler(Catch), sigINT, sigTERM)
 import Control.Concurrent (forkIO, killThread)
@@ -75,9 +78,16 @@ runWatch opt = do
   s <- getFileStatus canonicalPath
   let filetype = if isDirectory s then Directory else File
 
-  runTrigger <- newEmptyMVar
-  runThread <- forkIO $ runCmd cmd args runTrigger
-  stopWatcher <- watch filetype m canonicalPath runTrigger opt
+  -- Check if throttling was requested.
+  let delay = throttlingDelay opt
+  let pipeline = if delay > 0 then throttle delay else id
+
+  inputMVar <- newEmptyMVar
+  (pipelineThreads, outputMVar) <- runPipeline pipeline inputMVar
+  runThread <- forkIO $ runCmd cmd args outputMVar
+  stopWatcher <- watch filetype m canonicalPath inputMVar opt
+  
+  let allThreads = runThread : pipelineThreads
 
   -- Calculate the full path in order to print the "real" file when watching a
   -- path with one or more symlinks.
@@ -93,7 +103,7 @@ runWatch opt = do
   putStrLn "\nStopping."
   stopWatcher
   stopManager m
-  killThread runThread
+  mapM_ killThread allThreads
   exitSuccess
 
 main :: IO ()

--- a/fswatcher.hs
+++ b/fswatcher.hs
@@ -18,6 +18,7 @@ import Text.Regex.PCRE
 import Options.Applicative
 
 import Opts
+import Pipeline
 
 data FileType = File | Directory deriving Eq
 


### PR DESCRIPTION
fswatcher was producing two events every time I saved a file in my editor (vim), which caused my build script to run several times in a row for no reason. With this throttling option, I can now tell fswatcher to ignore the duplicate events.