### PR TITLE
COMMAND must have at least one element

### DIFF
--- a/src/Opts.hs
+++ b/src/Opts.hs
@@ -26,5 +26,5 @@ watchOpt = WatchOpt
                     <> value 0
                     <> metavar "MILLIS"
                     <> help "milliseconds to wait for duplicate events")
-     <*> (many . strArgument) (metavar "COMMAND"
+     <*> (some . strArgument) (metavar "COMMAND"
                       <> help "command to run" )


### PR DESCRIPTION
'many' allows zero or more elements, while 'some' allows one or more.
This fixes a bug whereby the following invocation:

  $ fswatcher --path foo

failed with "Prelude.head: empty list" when "foo" was modified. With
this fix, the invocation now displays "Missing: COMMAND" followed by the
usage help.