### PR TITLE
Require base >= 4.11

### DIFF
--- a/fswatcher.cabal
+++ b/fswatcher.cabal
@@ -11,13 +11,13 @@ License-file:       LICENSE
 author:             Erlend Hamberg
 maintainer:         ehamberg@gmail.com
 stability:          experimental
-tested-with:        GHC==7.6.3, GHC==8.4.4
+tested-with:        GHC==8.4.4
 homepage:           http://www.github.com/ehamberg/fswatcher/
 cabal-version:      >= 1.6
 
 
 Executable fswatcher
-    build-depends:   base            >= 4 && < 5
+    build-depends:   base            >= 4.11 && < 5
                    , unix            >= 2.5
                    , process         >= 1.1
                    , fsnotify        >= 0.3 && < 0.4


### PR DESCRIPTION
With older versions, GHC reports errors like:

    src/Opts.hs:30:23: error:
        • Variable not in scope:
            (<>) :: Mod f15 a14 -> Mod f16 a15 -> Mod ArgumentFields String
        • Perhaps you meant one of these:
            ‘<$>’ (imported from Options.Applicative),
            ‘<*>’ (imported from Options.Applicative),
            ‘*>’ (imported from Options.Applicative)
       |
    30 |                       <> help "command to run" )
       |                       ^^